### PR TITLE
fix NRP plugin for Jupyter-AI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,8 +29,6 @@ dependencies:
 - rasterstats==0.20.0
 - leafmap[mablibregl]
 - streamlit==1.39.0
-- langchain-core==0.3.7
-- langchain-openai==0.2.1
 
 # other packages
 - altair==5.4.1
@@ -44,6 +42,8 @@ dependencies:
 - pip==24.2
 - pip:
   - jupyter-ai==2.24.0
+  - langchain-ollama==0.1.3
+  - langchain-openai==0.1.25
   - nbconvert[webpdf]==7.16.4
   - git+https://github.com/eodaGmbH/py-maplibregl@feature/color-utils
   - git+https://gitlab.nrp-nautilus.io/prp/jupyter-ai-nrp


### PR DESCRIPTION
Looks like NRP plugin requires we install langchain dependencies via pip, not conda.  With this change, we can now select the National Research Platform as our LLM provider in jupyter-ai :robot: :man_dancing: 

![image](https://github.com/user-attachments/assets/72cb0d0e-a636-482d-b0b2-30ae53748255)
