### PR TITLE
Install jupyter-{rsession,shiny}-proxy.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,19 +7,22 @@ dependencies:
 
 # Items required for basic level functionality
 - gh-scoped-creds==4.1
-- git==2.46.0
+- git==2.47.1
 - jupyter-resource-usage=1.1.0
 - jupyterhub==5.2.1
-- jupyterlab==4.2.5
-- jupyter_server==2.14.2
-- jupyterlab-git==0.50.1
-- jupytext==1.16.4
+- jupyterlab==4.3.4
+- jupyter_server==2.15.0
+- jupyterlab-git==0.50.2
+- jupytext==1.16.6
 - nbgitpuller==1.2.1
-- notebook==7.2.2
+- notebook==7.3.2
 - python==3.11.*
 
+# r2d installs jupyter-rsession-proxy, but in the base python env, not in the updated one
+- jupyter-rsession-proxy==2.3.0
+
 # vscode
-- code-server==4.23.1
+- code-server==4.96.2
 - jupyter-vscode-proxy==0.6
 
 # llm packages
@@ -40,15 +43,17 @@ dependencies:
 - jupyterlab-myst==2.4.2
 - latexmk==4.85
 - leafmap==0.36.10
-- mystmd==1.3.17
+- mystmd==1.3.20
 - planetary-computer==1.0.0
 - pypdf==5.0.1
 - seaborn==0.13.2
  
 # pip installed packages, conda is prefered
-- pip==24.2
+- pip==24.3.1
 - pip:
-  - jupyter-ai==2.24.0
+  - jupyter-ai==2.28.5
+  # r2d installs jupyter-shiny-proxy, but in the base python env, not in the updated one
+  - jupyter-shiny-proxy==1.3
   - langchain-ollama==0.1.3
   - langchain-openai==0.1.25
   - nbconvert[webpdf]==7.16.4


### PR DESCRIPTION
These are installed by repo2docker, but they get installed with the default python's (3.10) libraries. When we upgrade python in environment.yml, and when jupyter server launches from there, it doesn't see the previously installed proxies. So we have to install them ourselves.

Also update other libraries. This could have been done in a separate commit.