### PR TITLE
testing out the build pipeline for R and vscode extensions

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -52,3 +52,5 @@ libgbm1
 libasound2
 
 net-tools
+htop
+


### PR DESCRIPTION
DO NOT MERGE

i want to see if:

1) only one version of R is installed (what's specified in `runtime.txt`).  i'm finding that (for some reason) conda installs the latest version of R on top of what is specified in `runtime.txt`.

2) ensure that `install.R` is executed and doesn't fail out when complaining about not having a CRAN mirror.

~~3) vscode extensions are downloaded and installed~~ there must have been a short outage that impacted things as this step now works

i'm seeing all three of these 'behaviors' when i'm building locally and in my CI.

to make sure that i'm not crazy, i downgraded my version of `repo2docker` locally to be `2024.07.0` from `2025.08.0` (my CI is running the latter version).  even then, i'm still seeing these problems, and was curious if a nature build would fail or exhibit the same issues.

if things continue to behave in a wonky way i will be opening up an upstream issue for at least the first 2 of the 3 things.